### PR TITLE
workaround failed to load when upload is not triggered directly by user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ http://labs.positronic.fr/flash/multipart/
 
 In Flash Player 10 and later, if you use a multipart Content-Type (for example "multipart/form-data") that contains an upload (indicated by a "filename" parameter in a "content-disposition" header within the POST body), the POST operation is subject to the security rules applied to uploads:
 
-*   The POST operation must be performed in response to a user-initiated action, such as a mouse click or key press.  
 *   If the POST operation is cross-domain (the POST target is not on the same server as the SWF file that is sending the POST request), the target server must provide a URL policy file that permits cross-domain access.
 
 http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/package.html

--- a/src/com/jonas/net/Multipart.as
+++ b/src/com/jonas/net/Multipart.as
@@ -4,6 +4,7 @@ package com.jonas.net
 	import flash.net.URLLoader;
 	import flash.net.URLRequest;
 	import flash.net.URLRequestMethod;
+	import flash.net.URLRequestHeader;
 	import flash.utils.ByteArray;
 
 	/**
@@ -71,7 +72,7 @@ package com.jonas.net
 			var r: URLRequest = new URLRequest(_url);
 			r.data = _data;
 			r.method = URLRequestMethod.POST;
-			r.contentType = "multipart/form-data; boundary=" + boundary;
+			r.requestHeaders.push( new URLRequestHeader('Content-type', 'multipart/form-data; boundary=' + boundary) );
 			
 			return r;
 			


### PR DESCRIPTION
the fix is pulled from here:
https://code.google.com/p/in-spirit/source/detail?r=118&path=/trunk/projects/MultipartURLLoader/ru/inspirit/net/MultipartURLLoader.as