### PR TITLE
Added encoding field

### DIFF
--- a/src/com/jonas/net/Multipart.as
+++ b/src/com/jonas/net/Multipart.as
@@ -19,9 +19,7 @@ package com.jonas.net
 		private var _fields:Array = [];
 		private var _files:Array = [];
 		private var _data:ByteArray = new ByteArray();
-		
-		//http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/charset-codes.html
-		public var encoding:String = 'ascii';
+		private var _encoding:String = 'ascii'; //http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/charset-codes.html
 
 		public function Multipart(url:String = null) {
 			_url = url;
@@ -92,10 +90,20 @@ package com.jonas.net
 		{
 			_url = value;
 		}
+		
+		public function get encoding():String 
+		{
+			return _encoding;
+		}
+		
+		public function set encoding(value:String):void 
+		{
+			_encoding = value;
+		}
 
 		private function _writeString(value:String):void {
 			var b:ByteArray = new ByteArray();
-			b.writeMultiByte(value, encoding);
+			b.writeMultiByte(value, _encoding);
 			_data.writeBytes(b, 0, b.length);
 		}
 

--- a/src/com/jonas/net/Multipart.as
+++ b/src/com/jonas/net/Multipart.as
@@ -19,6 +19,9 @@ package com.jonas.net
 		private var _fields:Array = [];
 		private var _files:Array = [];
 		private var _data:ByteArray = new ByteArray();
+		
+		//http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/charset-codes.html
+		public var encoding:String = 'ascii';
 
 		public function Multipart(url:String = null) {
 			_url = url;
@@ -92,7 +95,7 @@ package com.jonas.net
 
 		private function _writeString(value:String):void {
 			var b:ByteArray = new ByteArray();
-			b.writeMultiByte(value, "ascii");
+			b.writeMultiByte(value, encoding);
 			_data.writeBytes(b, 0, b.length);
 		}
 


### PR DESCRIPTION
Sometimes you need to use another encoding.
It would be great to seperate data which should be encoded from HTTP request strings which should be ascii, but for encodings that are the same as ascii for lower part of table (like utf-8) it works as it is.